### PR TITLE
Chibi-Scheme compatibility wrapper

### DIFF
--- a/==-tests.scm
+++ b/==-tests.scm
@@ -5,27 +5,27 @@
 (test "2"
   (run* (q)
   (conde
-    [(== 5 q)]
-    [(== 6 q)]))
+    ((== 5 q))
+    ((== 6 q))))
   '(5 6))
 
 (test "3"
   (run* (q)
   (fresh (a d)
     (conde
-      [(== 5 a)]
-      [(== 6 d)])
+      ((== 5 a))
+      ((== 6 d)))
     (== `(,a . ,d) q)))
   '((5 . _.0) (_.0 . 6)))
 
 (define appendo
   (lambda (l s out)
     (conde
-      [(== '() l) (== s out)]
-      [(fresh (a d res)
+      ((== '() l) (== s out))
+      ((fresh (a d res)
          (== `(,a . ,d) l)
          (== `(,a . ,res) out)
-         (appendo d s res))])))
+         (appendo d s res))))))
 
 (test "4"
   (run* (q) (appendo '(a b c) '(d e) q))
@@ -41,7 +41,7 @@
 
 (test "7"
   (run 5 (q)
-  (fresh (l s out)    
+  (fresh (l s out)
     (appendo l s out)
     (== `(,l ,s ,out) q)))
   '((() _.0 _.0)

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ For example, `(run (q r s) (== (cons r q) s))`.
 (load "mk-chicken.scm")
 ```
 
+### Chibi-Scheme
+
+```
+(load "mk-chibi.scm")
+```
+
 ## Running Tests
 
 After loading miniKanren as above,

--- a/mk-chibi.scm
+++ b/mk-chibi.scm
@@ -1,0 +1,85 @@
+;; (load "mk-chibi.scm")
+;; (load "test-all.scm")
+
+;; https://srfi.schemers.org/srfi-28/srfi-28.html
+(define format
+  (lambda (format-string . objects)
+    (let ((buffer (open-output-string)))
+      (let loop ((format-list (string->list format-string))
+                 (objects objects))
+        (cond ((null? format-list) (get-output-string buffer))
+              ((char=? (car format-list) #\~)
+               (if (null? (cdr format-list))
+                   (error 'format "Incomplete escape sequence")
+                   (case (cadr format-list)
+                     ((#\a)
+                      (if (null? objects)
+                          (error 'format "No value for escape sequence")
+                          (begin
+                            (display (car objects) buffer)
+                            (loop (cddr format-list) (cdr objects)))))
+	             ((#\s)
+                      (if (null? objects)
+                          (error 'format "No value for escape sequence")
+                          (begin
+                            (write (car objects) buffer)
+                            (loop (cddr format-list) (cdr objects)))))
+                     ((#\%)
+                      (newline buffer)
+                      (loop (cddr format-list) objects))
+                     ((#\~)
+                      (write-char #\~ buffer)
+                      (loop (cddr format-list) objects))
+                     (else
+                      (error 'format "Unrecognized escape sequence")))))
+              (else (write-char (car format-list) buffer)
+                    (loop (cdr format-list) objects)))))))
+
+(define (printf . args)
+  (display (apply format args)))
+
+(define (sub1 n)
+  (- n 1))
+
+(import (srfi 95))
+(define (list-sort x y) (sort y x))
+
+(define (exists p l)
+  (if (null? l)
+    #f
+    (let ((res (p (car l))))
+      (if (null? (cdr l))
+        res
+        (if res
+          res
+          (exists p (cdr l)))))))
+
+(import (srfi 1))
+#;(define (find p l)
+  (if (null? l)
+      #f
+      (if (p (car l))
+          (car l)
+          (find p (cdr l)))))
+
+(define (remp p l)
+  (if (null? l)
+      '()
+      (if (p (car l))
+          (remp p (cdr l))
+          (cons (car l) (remp p (cdr l))))))
+
+(define (for-all p l)
+  (if (null? l)
+    #t
+    (let ((res (p (car l))))
+      (if (null? (cdr l))
+        res
+        (if res
+          (for-all p (cdr l))
+          #f)))))
+
+(import (chibi io))
+(define call-with-string-output-port call-with-output-string)
+
+(load "mk.scm")

--- a/test-infer.scm
+++ b/test-infer.scm
@@ -1,17 +1,17 @@
 (define !-
   (lambda (exp env t)
     (conde
-      [(symbolo exp) (lookupo exp env t)]
-      [(fresh (x e t-x t-e)
+      ((symbolo exp) (lookupo exp env t))
+      ((fresh (x e t-x t-e)
          (== `(lambda (,x) ,e) exp)
          (symbolo x)
          (not-in-envo 'lambda env)
          (== `(-> ,t-x ,t-e) t)
-         (!- e `((,x . ,t-x) . ,env) t-e))]
-      [(fresh (rator rand t-x)
+         (!- e `((,x . ,t-x) . ,env) t-e)))
+      ((fresh (rator rand t-x)
          (== `(,rator ,rand) exp)
          (!- rator env `(-> ,t-x ,t))
-         (!- rand env t-x))])))
+         (!- rand env t-x))))))
 
 (define lookupo
   (lambda (x env t)


### PR DESCRIPTION
I added a compatibility wrapper for Chibi-Scheme called `mk-chibi.scm`. For this I had to change some more brakets to parenthesis in the test files. All tests have passed although "40 quines" and "4 thrines" have taken quite long to succeed.